### PR TITLE
chore: housekeeping — add prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "tsc --build",
     "build:nocheck": "tsc --noEmitOnError false",
     "clean": "tsc --build --clean & rm -rf ./artifacts*",
+    "prepare": "tsc --build",
     "test": "npm run build && node --test ./test/*.test.js",
     "test:debug": "npm run build:nocheck && DEBUG=ipfs-artifact-fetcher:* node --test ./test/*.test.js",
     "test:only": "npm run build && node --test-only ./test/*.test.js",


### PR DESCRIPTION
Part of an org-wide cleanup: every reloaded package should be installable as a git+https dep without hand-rolled bootstrap scripts.

## Context

When npm installs a git+https dep, it runs the dep's `prepare` script (if any) to build before linking. Without it, consumers get a `.ts`-only tree and crash at runtime requiring `src/index.js`. Every other reloaded package now ships `"prepare": "tsc --build"`.

## Change

Add `"prepare": "tsc --build"` to `package.json` scripts.

`.npmignore` is already present in this repo, so no other change needed.