### PR TITLE
chore: drop stale helia entry from package-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@helia/verified-fetch": "^5.1.1",
         "brotli": "^1.3.3",
         "debug": "^4.4.3",
-        "helia": "^6.0.14",
         "multiformats": "^13.4.2"
       },
       "devDependencies": {


### PR DESCRIPTION
The top-level `helia` dep was removed from `package.json` (replaced by `@helia/verified-fetch`) but the lockfile still listed it under the root package's dependencies. `npm install` refreshes the lock to match the actual dependency tree.